### PR TITLE
Add:missing command type describe for rfcredux

### DIFF
--- a/lib/commands/component.js
+++ b/lib/commands/component.js
@@ -23,7 +23,8 @@ exports.builder = (yargs) => {
                rfcp --> react functional component with proptypes
                rafc --> react arrow functional component
                rafcp --> react arrow functional component with proptypes
-               rafcredux --> react arrow functional component with connected redux`,
+               rafcredux --> react arrow functional component with connected redux
+               rfcredux --> react functional component with connected redux`,
     type: "string",
     default: "rfc",
     choices: validTypes,


### PR DESCRIPTION
Added the missing rfcredux command description in yargs.positional describe